### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/google-analytics-admin/properties_data_streams_measurement_protocol_secrets_update.py
+++ b/google-analytics-admin/properties_data_streams_measurement_protocol_secrets_update.py
@@ -75,7 +75,7 @@ def update_measurement_protocol_secret(
 
     print("Result:")
     print(f"Resource name: {measurement_protocol_secret.name}")
-    print(f"Secret value: {measurement_protocol_secret.secret_value}")
+    print("Secret value: [REDACTED]")
     print(f"Display name: {measurement_protocol_secret.display_name}")
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Arckimking86/python-docs-samples/security/code-scanning/4](https://github.com/Arckimking86/python-docs-samples/security/code-scanning/4)

The core of the issue is logging the sensitive field `measurement_protocol_secret.secret_value` in clear text. To fix this, we should avoid printing the secret value. The best security practice is simply to not log the secret at all. If it is necessary to indicate that a secret exists, we can print a placeholder (e.g., "[REDACTED]" or "[HIDDEN]") instead of the actual value.

To implement the changes:
- Edit only line 78 of the file `google-analytics-admin/properties_data_streams_measurement_protocol_secrets_update.py`.
- Remove or redact the print statement that outputs the secret value.
- Do not make any unnecessary modifications to other parts of the code.

No additional imports or method definitions are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
